### PR TITLE
First trial of commit

### DIFF
--- a/pycg/machinery/callgraph.py
+++ b/pycg/machinery/callgraph.py
@@ -36,7 +36,7 @@ class CallGraph(object):
             self.cg_extended[name] = {
                 'dsts' : [],
                 'meta' : {
-                    'modename' : modname
+                    'modname' : modname
                 }
             }
             self.modnames[name] = modname

--- a/pycg/machinery/callgraph.py
+++ b/pycg/machinery/callgraph.py
@@ -33,10 +33,12 @@ class CallGraph(object):
 
         if not name in self.cg:
             self.cg[name] = set()
-            self.cg_extended[name] = dict()
-            self.cg_extended[name]['dsts'] = []
-            self.cg_extended[name]['meta'] = dict()
-            self.cg_extended[name]['meta']['modname'] = modname
+            self.cg_extended[name] = {
+                'dsts' : [],
+                'meta' : {
+                    'modename' : modname
+                }
+            }
             self.modnames[name] = modname
 
         if name in self.cg and not self.modnames[name]:


### PR DESCRIPTION
Fix some extremely minor efficiency of python dict initialisation.

Multiple source analysing dict() vs {} shows that {} literal initialisation requires less time and resources and are more "pythonic".

https://doughellmann.com/posts/the-performance-impact-of-using-dict-instead-of-in-cpython-2-7-2/
http://katrin-affolter.ch/Python/Python_dictionaries