### PR TITLE
Fix bug: External call linkage has been ignored

### DIFF
--- a/pycg/machinery/definitions.py
+++ b/pycg/machinery/definitions.py
@@ -200,6 +200,9 @@ class Definition(object):
     def is_function_def(self):
         return self.def_type == utils.constants.FUN_DEF
 
+    def is_class_def(self):
+        return self.def_type == utils.constants.CLS_DEF
+
     def is_ext_def(self):
         return self.def_type == utils.constants.EXT_DEF
 

--- a/pycg/processing/base.py
+++ b/pycg/processing/base.py
@@ -238,10 +238,14 @@ class ProcessingBase(ast.NodeVisitor):
                     continue
 
                 return_ns = utils.constants.INVALID_NAME
-                if called_def.get_type() == utils.constants.FUN_DEF:
+                if called_def.is_function_def():
                     return_ns = utils.join_ns(called_def.get_ns(), utils.constants.RETURN_NAME)
-                elif called_def.get_type() == utils.constants.CLS_DEF:
+                elif called_def.is_class_def():
                     return_ns = called_def.get_ns()
+                elif called_def.is_ext_def():
+                    return_ns_set = called_def.get_name_pointer().get()
+                    if return_ns_set:
+                        return_ns = return_ns_set.pop()
                 defi = self.def_manager.get(return_ns)
                 if defi:
                     return_defs.append(defi)


### PR DESCRIPTION
This PR is to fix a problem in the processing **ast.Assign** object.
One of the important step for processing **ast.Assign** object is to translate variable type to its full name following previous definitions. Those definitions are stored in separate **ast.definition** object within the Scope Manager. 

While processing, it will search recursively from the bottom of the tree to the top of the tree for matching scope and its full naming for linking purpose. The decode_node function in https://github.com/AdaLogics/PyCG/blob/master/pycg/processing/base.py#L229-L249
indeed try to search through the names and provide separate handling for different name definition type

But in 
https://github.com/AdaLogics/PyCG/blob/master/pycg/processing/base.py#L241-L244

Only function **type (FUN_DEF)** and **class type (CLS_DEF)** record are being handled. This handling has ignored **external type (EXT_DEF)** which refer to naming for external import module. Thus all external modules return empty string for the processing and lost the linkage to their parent function definition.

This PR aims to fix this bug by adding additional handling code for external type definition. And also change the if condition to use the native checking function provided by the definition class,