### PR TITLE
Fix bug

### DIFF
--- a/pycg/processing/base.py
+++ b/pycg/processing/base.py
@@ -245,7 +245,7 @@ class ProcessingBase(ast.NodeVisitor):
                 elif called_def.is_ext_def():
                     return_ns_set = called_def.get_name_pointer().get()
                     if return_ns_set:
-                        return_ns = return_ns_set.pop()
+                        return_ns = next(iter(return_ns_set))
                 defi = self.def_manager.get(return_ns)
                 if defi:
                     return_defs.append(defi)

--- a/pycg/processing/cgprocessor.py
+++ b/pycg/processing/cgprocessor.py
@@ -269,6 +269,9 @@ class CallGraphProcessor(ProcessingBase):
 
         self.last_called_names = names
         for pointer in names:
+            pointer_init = "%s.__init__" % pointer
+            if pointer_init in self.scope_manager.get_scopes().keys():
+                pointer = pointer_init
             pointer_def = self.def_manager.get(pointer)
             if not pointer_def or not isinstance(pointer_def, Definition):
                 continue


### PR DESCRIPTION
Fix new bug introducing from PR #3.
- The name definition has been pop out and removed accidentally, cause further name decode fail in later code.

Fix the interpretation of constructor call
- Whenever a function call is visited, if its __init__ definition exits, it means it is an constructor call and change the name definition before adding edges.  