### PR TITLE
Updated importlib.abc import.

### DIFF
--- a/pycg/machinery/imports.py
+++ b/pycg/machinery/imports.py
@@ -21,7 +21,7 @@
 import sys
 import ast
 import os
-import importlib
+import importlib.abc
 import copy
 import logging
 


### PR DESCRIPTION
Fixes import error in upstream python versions. 

```
    class CustomLoader(importlib.abc.SourceLoader):
                       ^^^^^^^^^^^^^
AttributeError: module 'importlib' has no attribute 'abc'
```
