### PR TITLE
Use native set.update

### DIFF
--- a/pycg/machinery/definitions.py
+++ b/pycg/machinery/definitions.py
@@ -85,11 +85,11 @@ class DefinitionManager(object):
     def transitive_closure(self):
         closured = {}
         def dfs(defi):
-            name_pointer = defi.get_name_pointer()
-            new_set = set()
             # bottom
             if not closured.get(defi.get_ns(), None) == None:
                 return closured[defi.get_ns()]
+            name_pointer = defi.get_name_pointer()
+            new_set = set()
 
             if not name_pointer.get():
                 new_set.add(defi.get_ns())
@@ -102,7 +102,7 @@ class DefinitionManager(object):
                 items = dfs(self.defs[name])
                 if not items:
                     items = set([name])
-                new_set = new_set.union(items)
+                new_set.update(items)
 
             closured[defi.get_ns()] = new_set
             return closured[defi.get_ns()]

--- a/pycg/machinery/pointers.py
+++ b/pycg/machinery/pointers.py
@@ -34,7 +34,7 @@ class Pointer(object):
 
     def add_set(self, s):
         #logger.debug("In Pointer.add_set")
-        self.values = self.values.union(s)
+        self.values.update(s)
 
     def get(self):
         #logger.debug("In Pointer.get")
@@ -42,7 +42,7 @@ class Pointer(object):
 
     def merge(self, pointer):
         #logger.debug("In Pointer.merge")
-        self.values = self.values.union(pointer.values)
+        self.values.update(pointer.values)
 
 class LiteralPointer(Pointer):
     STR_LIT = "STRING"
@@ -88,7 +88,7 @@ class NamePointer(Pointer):
         if isinstance(item, str):
             self.args[name].add(item)
         elif isinstance(item, set):
-            self.args[name] = self.args[name].union(item)
+            self.args[name].update(item)
         else:
             raise Exception()
 

--- a/pycg/processing/base.py
+++ b/pycg/processing/base.py
@@ -70,7 +70,7 @@ class ProcessingBase(ast.NodeVisitor):
 
     def merge_modules_analyzed(self, analyzed):
         logger.debug("In ProcessingBase.merge_modules_analyzed")
-        self.modules_analyzed = self.modules_analyzed.union(analyzed)
+        self.modules_analyzed.update(analyzed)
         logger.debug("Exit ProcessingBase.merge_modules_analyzed")
 
     @property
@@ -430,7 +430,7 @@ class ProcessingBase(ast.NodeVisitor):
             if not parent or not isinstance(parent, Definition):
                 continue
             if getattr(self, "closured", None) and self.closured.get(parent.get_ns(), None):
-                names = names.union(self.closured.get(parent.get_ns()))
+                names.update(self.closured.get(parent.get_ns()))
             else:
                 names.add(parent.get_ns())
         #logger.debug("Exit ProcessingBase._retrieve_parent_names")
@@ -457,7 +457,7 @@ class ProcessingBase(ast.NodeVisitor):
                     cls_names = self.find_cls_fun_ns(defi.get_ns(), node.attr)
                     if cls_names:
                         #logger.debug("D-3.1-2")
-                        names = names.union(cls_names)
+                        names.update(cls_names)
                 #logger.debug("D-3.2")
                 if defi.is_function_def() or defi.is_module_def():
                     #logger.debug("D-3.3")

--- a/pycg/processing/postprocessor.py
+++ b/pycg/processing/postprocessor.py
@@ -174,7 +174,7 @@ class PostProcessor(ProcessingBase):
                         if self.closured.get(return_ns, None) == None:
                             continue
 
-                        new_previous_names = new_previous_names.union(self.closured.get(return_ns))
+                        new_previous_names.update(self.closured.get(return_ns))
 
                         for prev_name in previous_names:
                             pos_arg_names = d.get_name_pointer().get_pos_arg(0)

--- a/pycg/pycg.py
+++ b/pycg/pycg.py
@@ -158,7 +158,7 @@ class CallGraphGenerator(object):
                                 modules_analyzed=modules_analyzed, *args, **kwargs)
                 logger.info("Done analysis: %s"%(input_file))
                 processor.analyze()
-                modules_analyzed = modules_analyzed.union(processor.get_modules_analyzed())
+                modules_analyzed.update(processor.get_modules_analyzed())
 
                 if install_hooks:
                     self.remove_import_hooks()


### PR DESCRIPTION
Found multiple places where the original authors reassigned a set to the union of that set and another set instead of using .update(). Using the native set.update is easier to understand, more idiomatic, and faster.

Also in transitive_closure a new set and reference to a name pointer was being created in every loop even if it returned immediately after without using them, seems an obvious step to defer that.